### PR TITLE
inclusao de modo sandbox no layout de criação de documentos

### DIFF
--- a/src/autentique.class.php
+++ b/src/autentique.class.php
@@ -59,6 +59,11 @@
                 throw new \Exception('en-US: devMode expects boolean and '. gettype($val). ' are given! | pt-BR: devMode espera boolean e '. gettype($val). ' foi passado!');
 
             $this->apiInfo[$apiInfoName] = $val;
+
+            if($apiInfoName === 'devMode' && $this->layout instanceof createDoc){
+                $this->setDevMode($val);
+            }
+
         }
 
         /**
@@ -142,6 +147,17 @@
                 
             curl_close($c);
             return $r;
+        }
+
+        /**
+         * @description-en-US       Configure the use of the API on sandbox mode or not (document creation only)
+         * @description-pt-BR       Configura o uso da API no modo sandbox ou não  (apenas criação de documentos)
+         * @author                  João Manoel Borges < jm.borges7312@gmail.com >
+         * @param                   bool $devMode - true or false
+         * @return                  void
+         */
+        protected function setDevMode(bool $devMode): void{
+            $this->layout->setDevMode($devMode);
         }
     }
 ?>

--- a/test/createDoc.php
+++ b/test/createDoc.php
@@ -4,6 +4,7 @@
     use sysborg\autentiquev2\autentique;
     
     $token = ''; //en-US: put your autentique's token here https://www.autentique.com.br/ | pt-BR: coloque seu token da autentique aqui https://www.autentique.com.br/
+    $sandboxMode = false; //en-US: change the sandbox mode to create test documents, if wanted | pt-BR: mude o modo sandbox para criar documentos teste, se desejado
 
     /**
      * en-US: Calling the desired layout and passing the variables expecteds and disred. At this case the document creation and upload
@@ -22,6 +23,7 @@
     $t = new autentique($l);
     $t->debug=true;
     $t->token=$token;
+    $t->devMode=$sandboxMode;
     $r = $t->transmit();
     echo '//en-US: Clean response | pt-BR: Resposta limpa<br><pre>';
     var_dump($r); //en-US: Clean response | pt-BR: Resposta limpa


### PR DESCRIPTION
### Sumário das alterações:
#### em src/layouts/doc/createDoc.class.php:
- inclusão de propriedade protected $sandbox | Armazena informações sobre se o documento será criado no modo sandbox ou não
- alteração da propriedade $query | Incluido o trecho "sandbox: {{ %sandbox }}" na query para que ao ser parsed a query irá - substituir o placeholder {{ %sandbox }} com true ou false, conforme documentação da API https://docs.autentique.com.br/api/integracao/sandbox-testes
- inclusão de condicional no método parse | caso a propriedade $sandbox esteja vazia, é chamado o método setDevMove() com parametro false (deixa o layout em modo produção)
- inclusão de método setDevMode() | atribui valor true ou false para a propriedade $sandbox e substitui o placeholder da query com o valor desejado

#### em  src/autentique.class.php
- inclusão do método setDevMode(), que, ao ser invocado, chama o método setDevMode do layout.
- inclusão de condicional no método __set | caso a propriedade que está sendo definida for 'devMode' e o layout atual da classe autentique for o createDoc, invoca o método setDevMode com o valor definido

Também adicionei no teste de createDoc duas linhas, uma para que o usuário da biblioteca defina se será modo sandbox ou não, e outra que seta o valor definido no layout.

### Funcionamento

Na prática, a propriedade devMode da classe autentique pode ser definida como true ou false, e ao ser definida ela invoca o método setDevMode do layout que foi passado no constructor, atualizando a query. Ao ser invocado o método parse do layout, o código verifica se já existe um valor bool para sandbox, e se não existe, ele define por padrão como false (modo produção).

Dessa forma, mesmo que a pessoa que estiver usando a biblioteca não defina o modo sandbox explicitamente, ele por padrão fica como modo produção.

**Exemplo de uso:**

```  
$autentiqueToken = 'XXXXXXX';
$autentiqueDevMode = true;

$autentique = new autentique($queryLayout);
$autentique->token = $autentiqueToken;
$autentique->devMode = $autentiqueDevMode;

return $autentique->transmit();

```

##### Obs: Essa alteração atualmente se aplica apenas ao layout createDoc. Acabei não usando os demais layouts mas tentei ajustar de forma que essas alterações não interferissem nos outros layouts. 

Agradeço por disponibilizar essa biblioteca que foi bem simples de utilizar e bem útil.

Tentei deixar o mínimo invasiva essas alterações e também tentei deixar no padrão de documentação que vocês utilizaram, mas fiquem à vontade para sugerir qualquer alteração que seja necessária.